### PR TITLE
fix: gives default empty dict to the config of model

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -28,9 +28,10 @@ class Config(object):
         yconfig = self._load_config()
         logging.config.dictConfig(yconfig["logging"])
         self.GROUPS = yconfig["groups"]["enable"]
-        self.CHATGPT = yconfig.get("chatgpt")
         self.NEWS = yconfig["news"]["receivers"]
         self.REPORT_REMINDERS = yconfig["report_reminder"]["receivers"]
-        self.TIGERBOT = yconfig.get("tigerbot")
-        self.XINGHUO_WEB = yconfig.get("xinghuo_web")
-        self.CHATGLM = yconfig.get("chatglm")
+
+        self.CHATGPT = yconfig.get("chatgpt", {})
+        self.TIGERBOT = yconfig.get("tigerbot", {})
+        self.XINGHUO_WEB = yconfig.get("xinghuo_web", {})
+        self.CHATGLM = yconfig.get("chatglm", {})

--- a/robot.py
+++ b/robot.py
@@ -60,7 +60,9 @@ class Robot(Job):
 
     @staticmethod
     def value_check(args: dict) -> bool:
-        return all(value is not None for key, value in args.items() if key != 'proxy')
+        if args:
+            return all(value is not None for key, value in args.items() if key != 'proxy')
+        return False
 
     def toAt(self, msg: WxMsg) -> bool:
         """处理被 @ 消息


### PR DESCRIPTION
Giving default empty dict to the config of model in order to If the previous model configuration is annotated and you want to select the last model, parameter exceptions will occur in if...else...

After fixed, it can be compatible with comments.