### PR TITLE
新增智谱清言文生图功能

### DIFF
--- a/base/func_cogview.py
+++ b/base/func_cogview.py
@@ -1,0 +1,94 @@
+import logging
+import os
+import requests
+import tempfile
+import time
+from zhipuai import ZhipuAI
+
+class CogView():
+    def __init__(self, conf: dict) -> None:
+        self.api_key = conf.get("api_key")
+        self.model = conf.get("model", "cogview-4-250304") # 默认使用最新模型
+        self.quality = conf.get("quality", "standard")
+        self.size = conf.get("size", "1024x1024")
+        self.enable = conf.get("enable", True)
+        
+        project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        default_img_dir = os.path.join(project_dir, "zhipuimg")
+        self.temp_dir = conf.get("temp_dir", default_img_dir)
+        
+        self.LOG = logging.getLogger("CogView")
+        
+        if self.api_key:
+            self.client = ZhipuAI(api_key=self.api_key)
+            self.LOG.info(f"CogView 初始化成功，模型：{self.model}，质量：{self.quality}，图片保存目录：{self.temp_dir}")
+        else:
+            self.LOG.warning("未配置智谱API密钥，图像生成功能无法使用")
+            self.client = None
+        
+        os.makedirs(self.temp_dir, exist_ok=True)
+    
+    @staticmethod
+    def value_check(conf: dict) -> bool:
+        if conf and conf.get("api_key") and conf.get("enable", True):
+            return True
+        return False
+    
+    def __repr__(self):
+        return 'CogView'
+    
+    def generate_image(self, prompt: str) -> str:
+        """
+        生成图像并返回图像URL
+        
+        Args:
+            prompt (str): 图像描述
+            
+        Returns:
+            str: 生成的图像URL或错误信息
+        """
+        if not self.client or not self.enable:
+            return "图像生成功能未启用或API密钥未配置"
+        
+        try:
+            response = self.client.images.generations(
+                model=self.model,
+                prompt=prompt,
+                quality=self.quality,
+                size=self.size,
+            )
+            
+            if response and response.data and len(response.data) > 0:
+                return response.data[0].url
+            else:
+                return "图像生成失败，未收到有效响应"
+        except Exception as e:
+            self.LOG.error(f"图像生成出错: {str(e)}")
+            return f"图像生成出错: {str(e)}"
+    
+    def download_image(self, image_url: str) -> str:
+        """
+        下载图片并返回本地文件路径
+        
+        Args:
+            image_url (str): 图片URL
+            
+        Returns:
+            str: 本地图片文件路径，下载失败则返回None
+        """
+        try:
+            response = requests.get(image_url, stream=True, timeout=30)
+            if response.status_code == 200:
+                file_path = os.path.join(self.temp_dir, f"cogview_{int(time.time())}.jpg")
+                with open(file_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=1024):
+                        if chunk:
+                            f.write(chunk)
+                self.LOG.info(f"图片已下载到: {file_path}")
+                return file_path
+            else:
+                self.LOG.error(f"下载图片失败，状态码: {response.status_code}")
+                return None
+        except Exception as e:
+            self.LOG.error(f"下载图片过程出错: {str(e)}")
+            return None

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -113,3 +113,14 @@ deepseek:  # -----deepseek配置这行不填-----
   prompt: 你是智能聊天机器人，你叫 DeepSeek 助手  # 根据需要对角色进行设定
   enable_reasoning: false  # 是否启用思维链功能，仅在使用 deepseek-reasoner 模型时有效
   show_reasoning: false  # 是否在回复中显示思维过程，仅在启用思维链功能时有效
+
+cogview:  # -----智谱AI图像生成配置这行不填-----
+  #此API请参考 https://www.bigmodel.cn/dev/api/image-model/cogview
+  enable: False  # 是否启用图像生成功能，默认关闭，将False替换为true则开启，此模型可和其他模型同时运行。
+  api_key:  # 智谱API密钥，请填入您的API Key
+  model: cogview-4-250304  # 模型编码，可选：cogview-4-250304、cogview-4、cogview-3-flash
+  quality: standard  # 生成质量，可选：standard（快速）、hd（高清）
+  size: 1024x1024  # 图片尺寸，可自定义，需符合条件
+  trigger_keyword: 画一张  # 触发图像生成的关键词
+  temp_dir:  # 临时文件存储目录，留空则默认使用项目目录下的zhipuimg文件夹，如果要更改，例如 D:/Pictures/temp 或 /home/user/temp
+  fallback_to_chat: true  # 当未启用绘画功能时：true=将请求发给聊天模型处理，false=回复固定的未启用提示信息

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -115,7 +115,7 @@ deepseek:  # -----deepseek配置这行不填-----
   show_reasoning: false  # 是否在回复中显示思维过程，仅在启用思维链功能时有效
 
 cogview:  # -----智谱AI图像生成配置这行不填-----
-  #此API请参考 https://www.bigmodel.cn/dev/api/image-model/cogview
+  # 此API请参考 https://www.bigmodel.cn/dev/api/image-model/cogview
   enable: False  # 是否启用图像生成功能，默认关闭，将False替换为true则开启，此模型可和其他模型同时运行。
   api_key:  # 智谱API密钥，请填入您的API Key
   model: cogview-4-250304  # 模型编码，可选：cogview-4-250304、cogview-4、cogview-3-flash

--- a/configuration.py
+++ b/configuration.py
@@ -11,6 +11,7 @@ import yaml
 
 class Config(object):
     def __init__(self) -> None:
+        self.COGVIEW = {}
         self.reload()
 
     def _load_config(self) -> dict:
@@ -42,4 +43,5 @@ class Config(object):
         self.BardAssistant = yconfig.get("bard", {})
         self.ZhiPu = yconfig.get("zhipu", {})
         self.DEEPSEEK = yconfig.get("deepseek", {})
+        self.COGVIEW = yconfig.get("cogview", {})
         self.SEND_RATE_LIMIT = yconfig.get("send_rate_limit", 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ jupyter_client
 zhdate
 ipykernel
 google-generativeai
-zhipuai
+zhipuai>=1.0.0
 ollama


### PR DESCRIPTION
支持根据配置生成和下载图像到自定义文件夹内并发送，更改群内@聊天逻辑，加入触发文生图功能。如果管理员未开启文生图，则默认调用其他语言模型，也可设置回复固定信息来减少模型的调用，优化用户的使用体验。