### PR TITLE
文生图模型官方BUG更新，适配返回数据

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,6 +31,8 @@ git clone https://gitee.com/lch0821/WeChatRobot.git
 python -m pip install -U pip
 # 安装必要依赖
 pip install -r requirements.txt
+# 国内用户可能会因为网络问题出现安装失败，届时可使用镜像源来下载
+pip install -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com -r requirements.txt
 # ChatGLM 还需要安装一个 kernel
 ipython kernel install --name chatglm3 --user
 ```

--- a/base/func_aliyun_image.py
+++ b/base/func_aliyun_image.py
@@ -1,0 +1,108 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+import time
+from http import HTTPStatus
+from urllib.parse import urlparse, unquote
+from pathlib import PurePosixPath
+
+import requests
+from dashscope import ImageSynthesis
+import dashscope
+
+class AliyunImage():
+    """阿里文生图API调用
+    """
+
+    @staticmethod
+    def value_check(args: dict) -> bool:
+        try:
+            return bool(args and args.get("api_key", "") and args.get("model", ""))
+        except Exception:
+            return False
+
+    def __init__(self, config={}) -> None:
+        self.LOG = logging.getLogger("AliyunImage")
+        if not config:
+            raise Exception("缺少配置信息")
+            
+        self.api_key = config.get("api_key", "")
+        self.model = config.get("model", "wanx2.1-t2i-turbo")
+        self.size = config.get("size", "1024*1024")
+        self.enable = config.get("enable", True)
+        self.n = config.get("n", 1)
+        self.temp_dir = config.get("temp_dir", "./temp")
+        
+        # 确保临时目录存在
+        if not os.path.exists(self.temp_dir):
+            os.makedirs(self.temp_dir)
+            
+        # 设置API密钥
+        dashscope.api_key = self.api_key
+        
+        self.LOG.info("AliyunImage 已初始化")
+
+    def generate_image(self, prompt: str) -> str:
+        """生成图像并返回图像URL
+        
+        Args:
+            prompt (str): 图像描述
+            
+        Returns:
+            str: 生成的图像URL或错误信息
+        """
+        if not self.enable or not self.api_key:
+            return "阿里文生图功能未启用或API密钥未配置"
+        
+        try:
+            rsp = ImageSynthesis.call(
+                api_key=self.api_key,
+                model=self.model,
+                prompt=prompt,
+                n=self.n,
+                size=self.size
+            )
+            
+            if rsp.status_code == HTTPStatus.OK and rsp.output and rsp.output.results:
+                return rsp.output.results[0].url
+            else:
+                self.LOG.error(f"图像生成失败: {rsp.code}, {rsp.message}")
+                return f"图像生成失败: {rsp.message}"
+        except Exception as e:
+            error_str = str(e)
+            self.LOG.error(f"图像生成出错: {error_str}")
+            
+            if "Error code: 500" in error_str or "HTTP/1.1 500" in error_str:
+                self.LOG.warning(f"检测到违规内容请求: {prompt}")
+                return "很抱歉，您的请求可能包含违规内容，无法生成图像"
+
+            return "图像生成失败，请调整您的描述后重试"
+
+    def download_image(self, image_url: str) -> str:
+        """
+        下载图片并返回本地文件路径
+        
+        Args:
+            image_url (str): 图片URL
+            
+        Returns:
+            str: 本地图片文件路径，下载失败则返回None
+        """
+        try:
+            response = requests.get(image_url, stream=True, timeout=30)
+            if response.status_code == 200:
+                file_path = os.path.join(self.temp_dir, f"aliyun_image_{int(time.time())}.jpg")
+                with open(file_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=1024):
+                        if chunk:
+                            f.write(chunk)
+                self.LOG.info(f"图片已下载到: {file_path}")
+                return file_path
+            else:
+                self.LOG.error(f"下载图片失败，状态码: {response.status_code}")
+                return None
+        except Exception as e:
+            self.LOG.error(f"下载图片过程出错: {str(e)}")
+            return None

--- a/base/func_cogview.py
+++ b/base/func_cogview.py
@@ -63,8 +63,14 @@ class CogView():
             else:
                 return "图像生成失败，未收到有效响应"
         except Exception as e:
-            self.LOG.error(f"图像生成出错: {str(e)}")
-            return f"图像生成出错: {str(e)}"
+            error_str = str(e)
+            self.LOG.error(f"图像生成出错: {error_str}")
+            
+            if "Error code: 500" in error_str or "HTTP/1.1 500" in error_str or "code\":\"1234\"" in error_str:
+                self.LOG.warning(f"检测到违规内容请求: {prompt}")
+                return "很抱歉，您的请求可能包含违规内容，无法生成图像"
+
+            return "图像生成失败，请调整您的描述后重试"
     
     def download_image(self, image_url: str) -> str:
         """

--- a/config.yaml.template
+++ b/config.yaml.template
@@ -121,6 +121,16 @@ cogview:  # -----智谱AI图像生成配置这行不填-----
   model: cogview-4-250304  # 模型编码，可选：cogview-4-250304、cogview-4、cogview-3-flash
   quality: standard  # 生成质量，可选：standard（快速）、hd（高清）
   size: 1024x1024  # 图片尺寸，可自定义，需符合条件
-  trigger_keyword: 画一张  # 触发图像生成的关键词
+  trigger_keyword: 牛智谱  # 触发图像生成的关键词
   temp_dir:  # 临时文件存储目录，留空则默认使用项目目录下的zhipuimg文件夹，如果要更改，例如 D:/Pictures/temp 或 /home/user/temp
   fallback_to_chat: true  # 当未启用绘画功能时：true=将请求发给聊天模型处理，false=回复固定的未启用提示信息
+
+aliyun_image:  # -----如果要使用阿里云文生图，取消下面的注释并填写相关内容，模型到阿里云百炼找通义万相-文生图2.1-Turbo-----
+  enable: true  # 是否启用阿里文生图功能，false为关闭，默认开启，如果未配置，则会将消息发送给聊天大模型
+  api_key: sk-xxxxxxxxxxxxxxxxxxxxxxxx  # 替换为你的DashScope API密钥
+  model: wanx2.1-t2i-turbo  # 模型名称，默认使用wanx2.1-t2i-turbo(快),wanx2.1-t2i-plus（中）,wanx-v1（慢），会给用户不同的提示！
+  size: 1024*1024  # 图像尺寸，格式为宽*高
+  n: 1  # 生成图像的数量
+  temp_dir: ./temp  # 临时文件存储路径
+  trigger_keyword: 牛阿里  # 触发词，默认为"牛阿里"
+  fallback_to_chat: true  # 当服务不可用时是否转发给聊天模型处理

--- a/configuration.py
+++ b/configuration.py
@@ -12,6 +12,7 @@ import yaml
 class Config(object):
     def __init__(self) -> None:
         self.COGVIEW = {}
+        self.ALIYUN_IMAGE = {}
         self.reload()
 
     def _load_config(self) -> dict:
@@ -44,4 +45,5 @@ class Config(object):
         self.ZhiPu = yconfig.get("zhipu", {})
         self.DEEPSEEK = yconfig.get("deepseek", {})
         self.COGVIEW = yconfig.get("cogview", {})
+        self.ALIYUN_IMAGE = yconfig.get("aliyun_image", {})
         self.SEND_RATE_LIMIT = yconfig.get("send_rate_limit", 0)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,15 @@ def main(chat_type: int):
     robot.LOG.info(f"WeChatRobot【{__version__}】成功启动···")
 
     # 机器人启动发送测试消息
-    robot.sendTextMsg("机器人启动成功！", "filehelper")
+    # 机器人启动发送测试消息
+    robot.sendTextMsg("机器人启动成功！\n"
+                     "🎨 绘画功能使用说明：\n"
+                     "• 智谱绘画：牛智谱[描述]\n"
+                     "• 阿里绘画：牛阿里[描述]\n"
+                     "实例：\n"
+                     "牛阿里 画一张家乡\n"
+                     "@XX 牛阿里 画一张家乡\n"
+                     "💬 聊天时直接发送消息即可", "filehelper")
 
     # 接收消息
     # robot.enableRecvMsg()     # 可能会丢消息？

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ ipykernel
 google-generativeai
 zhipuai>=1.0.0
 ollama
+dashscope


### PR DESCRIPTION
上午在测试中，无意中发现了模型可生成违规图片的问题，提交工单后，官方修复了这个BUG，随后原来的代码中，并没有加入对500错误的分析和操作，现添加逻辑“模型返回500错误后，向用户返回特定的文字内容”